### PR TITLE
Add a filter for GlobalConfiguration items based on permission

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -139,6 +139,8 @@ import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ModelObjectWithContextMenu;
 
+import org.acegisecurity.AccessDeniedException;
+import org.acegisecurity.Authentication;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyTagException;
 import org.apache.commons.jelly.Script;
@@ -1064,7 +1066,7 @@ public class Functions {
         List<Descriptor> answer = new ArrayList<>(r.size());
         for (Tag d : r) answer.add(d.d);
 
-        return DescriptorVisibilityFilter.apply(Jenkins.get(),answer);
+        return GlobalConfigHiddenByPermissionFilter.apply(Jenkins.get(),answer);
     }
 
     /**
@@ -1300,6 +1302,24 @@ public class Functions {
         ThreadGroupMap sorter = new ThreadGroupMap();
         Arrays.sort(list, sorter);
         return sorter;
+    }
+
+    @Extension
+    public static class GlobalConfigHiddenByPermissionFilter extends DescriptorVisibilityFilter {
+
+        @SuppressWarnings("rawtypes")
+        @Override
+        public boolean filter(Object context, Descriptor descriptor) {
+
+            try {
+                if (descriptor instanceof GlobalConfiguration) {
+                    Jenkins.get().checkPermission(((GlobalConfiguration) descriptor).getPermission());
+                }
+            } catch (AccessDeniedException e) {
+                return false;
+            }
+            return true;
+        }
     }
 
     // Common code for sorting Threads/ThreadInfos by ThreadGroup

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -139,8 +139,6 @@ import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ModelObjectWithContextMenu;
 
-import org.acegisecurity.AccessDeniedException;
-import org.acegisecurity.Authentication;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyTagException;
 import org.apache.commons.jelly.Script;
@@ -1066,7 +1064,7 @@ public class Functions {
         List<Descriptor> answer = new ArrayList<>(r.size());
         for (Tag d : r) answer.add(d.d);
 
-        return GlobalConfigHiddenByPermissionFilter.apply(Jenkins.get(),answer);
+        return GlobalConfiguration.GlobalConfigHiddenByPermissionFilter.apply(Jenkins.get(),answer);
     }
 
     /**
@@ -1302,24 +1300,6 @@ public class Functions {
         ThreadGroupMap sorter = new ThreadGroupMap();
         Arrays.sort(list, sorter);
         return sorter;
-    }
-
-    @Extension
-    public static class GlobalConfigHiddenByPermissionFilter extends DescriptorVisibilityFilter {
-
-        @SuppressWarnings("rawtypes")
-        @Override
-        public boolean filter(Object context, Descriptor descriptor) {
-
-            try {
-                if (descriptor instanceof GlobalConfiguration) {
-                    Jenkins.get().checkPermission(((GlobalConfiguration) descriptor).getPermission());
-                }
-            } catch (AccessDeniedException e) {
-                return false;
-            }
-            return true;
-        }
     }
 
     // Common code for sorting Threads/ThreadInfos by ThreadGroup

--- a/core/src/main/java/hudson/views/GlobalDefaultViewConfiguration.java
+++ b/core/src/main/java/hudson/views/GlobalDefaultViewConfiguration.java
@@ -25,6 +25,7 @@ package hudson.views;
 
 import hudson.Extension;
 import hudson.model.View;
+import hudson.security.Permission;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -57,6 +58,11 @@ public class GlobalDefaultViewConfiguration extends GlobalConfiguration {
         }
         
         return true;
+    }
+
+    @Override
+    public Permission getPermission() {
+        return Jenkins.CONFIGURE;
     }
 }
 

--- a/core/src/main/java/hudson/views/MyViewsTabBar.java
+++ b/core/src/main/java/hudson/views/MyViewsTabBar.java
@@ -36,6 +36,7 @@ import javax.annotation.Nonnull;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import hudson.model.MyViewsProperty;
+import hudson.security.Permission;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -114,6 +115,11 @@ public abstract class MyViewsTabBar extends AbstractDescribableImpl<MyViewsTabBa
             }
 
             return true;
+        }
+
+        @Override
+        public Permission getPermission() {
+            return Jenkins.CONFIGURE;
         }
     }
 }

--- a/core/src/main/java/hudson/views/ViewsTabBar.java
+++ b/core/src/main/java/hudson/views/ViewsTabBar.java
@@ -36,6 +36,7 @@ import javax.annotation.Nonnull;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import hudson.model.ListView;
+import hudson.security.Permission;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -115,6 +116,11 @@ public abstract class ViewsTabBar extends AbstractDescribableImpl<ViewsTabBar> i
             }
 
             return true;
+        }
+
+        @Override
+        public Permission getPermission() {
+            return Jenkins.CONFIGURE;
         }
     }
 }

--- a/core/src/main/java/jenkins/model/ArtifactManagerConfiguration.java
+++ b/core/src/main/java/jenkins/model/ArtifactManagerConfiguration.java
@@ -26,6 +26,7 @@ package jenkins.model;
 
 import hudson.Extension;
 import hudson.model.PersistentDescriptor;
+import hudson.security.Permission;
 import hudson.util.DescribableList;
 import java.io.IOException;
 import net.sf.json.JSONObject;

--- a/core/src/main/java/jenkins/model/ArtifactManagerConfiguration.java
+++ b/core/src/main/java/jenkins/model/ArtifactManagerConfiguration.java
@@ -66,4 +66,8 @@ public class ArtifactManagerConfiguration extends GlobalConfiguration implements
         }
     }
 
+    @Override
+    public Permission getPermission() {
+        return Jenkins.CONFIGURE;
+    }
 }

--- a/core/src/main/java/jenkins/model/GlobalConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalConfiguration.java
@@ -84,9 +84,10 @@ public abstract class GlobalConfiguration extends Descriptor<GlobalConfiguration
     }
 
     /**
-     * Assume by default that GlobalConfiguration items require Jenkins.ADMINISTER permission
+     * Returns the permission type needed in order to use/access this
+     * By default,  require Jenkins.ADMINISTER permission
      * Ovveride to return something different if appropriate
-     * @return Permission
+     * @return Permission requiered to use/access this
      */
     public Permission getPermission() {
         return Jenkins.ADMINISTER;

--- a/core/src/main/java/jenkins/model/GlobalConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalConfiguration.java
@@ -89,7 +89,7 @@ public abstract class GlobalConfiguration extends Descriptor<GlobalConfiguration
      * Ovveride to return something different if appropriate
      * @return Permission requiered to use/access this
      */
-    public Permission getPermission() {
+    public @Nonnull Permission getPermission() {
         return Jenkins.ADMINISTER;
     }
 
@@ -102,20 +102,16 @@ public abstract class GlobalConfiguration extends Descriptor<GlobalConfiguration
             boolean result = false;
             try {
                 if (descriptor instanceof GlobalConfiguration) {
-                    result = Functions.hasPermission(((GlobalConfiguration) descriptor).getPermission());
+                    return Functions.hasPermission(((GlobalConfiguration) descriptor).getPermission());
                 } else {
-                    result = true;
+                    return true;
                 }
             } catch (AccessDeniedException e) {
-                result =  false;
-            } catch (ServletException e) {
+                return false;
+            } catch (ServletException | IOException e) {
                 e.printStackTrace();
-                result = true;
-            } catch (IOException e) {
-                e.printStackTrace();
-                result = true;
+                return true;
             }
-                return result;
         }
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalConfiguration.java
@@ -103,15 +103,19 @@ public abstract class GlobalConfiguration extends Descriptor<GlobalConfiguration
             try {
                 if (descriptor instanceof GlobalConfiguration) {
                     result = Functions.hasPermission(((GlobalConfiguration) descriptor).getPermission());
+                } else {
+                    result = true;
                 }
             } catch (AccessDeniedException e) {
-                return false;
+                result =  false;
             } catch (ServletException e) {
                 e.printStackTrace();
+                result = true;
             } catch (IOException e) {
                 e.printStackTrace();
+                result = true;
             }
-            return result;
+                return result;
         }
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalConfiguration.java
@@ -4,6 +4,7 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import hudson.security.Permission;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -74,5 +75,14 @@ public abstract class GlobalConfiguration extends Descriptor<GlobalConfiguration
     public static @Nonnull ExtensionList<GlobalConfiguration> all() {
         return Jenkins.get().getDescriptorList(GlobalConfiguration.class);
         // pointless type parameters help work around bugs in javac in earlier versions http://codepad.org/m1bbFRrH
+    }
+
+    /**
+     * Assume by default that GlobalConfiguration items require Jenkins.ADMINISTER permission
+     * Ovveride to return something different if appropriate
+     * @return Permission
+     */
+    public Permission getPermission() {
+        return Jenkins.ADMINISTER;
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalProjectNamingStrategyConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalProjectNamingStrategyConfiguration.java
@@ -24,6 +24,7 @@
 package jenkins.model;
 
 import hudson.Extension;
+import hudson.security.Permission;
 import jenkins.model.ProjectNamingStrategy.DefaultProjectNamingStrategy;
 import net.sf.json.JSONObject;
 
@@ -58,5 +59,10 @@ public class GlobalProjectNamingStrategyConfiguration extends GlobalConfiguratio
             j.setProjectNamingStrategy(DefaultProjectNamingStrategy.DEFAULT_NAMING_STRATEGY);
         }
         return true;
+    }
+
+    @Override
+    public Permission getPermission() {
+        return Jenkins.CONFIGURE;
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalQuietPeriodConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalQuietPeriodConfiguration.java
@@ -24,6 +24,7 @@
 package jenkins.model;
 
 import hudson.Extension;
+import hudson.security.Permission;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
@@ -56,5 +57,10 @@ public class GlobalQuietPeriodConfiguration extends GlobalConfiguration {
         } catch (IOException e) {
             throw new FormException(e,"quietPeriod");
         }
+    }
+
+    @Override
+    public Permission getPermission() {
+        return Jenkins.CONFIGURE;
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalSCMRetryCountConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalSCMRetryCountConfiguration.java
@@ -24,6 +24,7 @@
 package jenkins.model;
 
 import hudson.Extension;
+import hudson.security.Permission;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
@@ -53,5 +54,10 @@ public class GlobalSCMRetryCountConfiguration extends GlobalConfiguration {
         } catch (JSONException e) {
             throw new FormException(e.getMessage(), "quietPeriod");
         }
+    }
+
+    @Override
+    public Permission getPermission() {
+        return Jenkins.CONFIGURE;
     }
 }


### PR DESCRIPTION
Add a filter for GlobalConfiguration items that are not accessible to a user without sufficient permission.  This prevents errors being shown in the UX if the GlobalConfiguration item being loaded requires a permission type that the current user doesn't have (see example screenshot below).

![Screen Shot 2019-12-14 at 2 44 06 PM](https://user-images.githubusercontent.com/8135503/70853753-49bd2080-1e80-11ea-9c83-a9f86c7df630.png)

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
