### PR TITLE
Fix failing test

### DIFF
--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -996,7 +996,7 @@ public class Fingerprint implements ModelObject, Saveable {
         final Jenkins instance = Jenkins.get();
         for (Entry<String, RangeSet> e : usages.entrySet()) {
             final String itemName = e.getKey();
-            if (instance.hasPermission(Jenkins.CONFIGURE) || canDiscoverItem(itemName)) {
+            if (instance.hasPermission(Jenkins.ADMINISTER) || canDiscoverItem(itemName)) {
                 r.add(new RangeItem(itemName, e.getValue()));
             }
         }

--- a/core/src/main/java/jenkins/management/PluginsLink.java
+++ b/core/src/main/java/jenkins/management/PluginsLink.java
@@ -52,5 +52,4 @@ public class PluginsLink extends ManagementLink {
     public String getUrlName() {
         return "pluginManager";
     }
-
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1911,7 +1911,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      }
 
     public void setPrimaryView(@Nonnull View v) {
-        checkPermission(ADMINISTER);
+        checkPermission(Permission.CONFIGURE);
         this.primaryView = v.getViewName();
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2527,7 +2527,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Everything below here is admin-only, so do the check here.
      */
     public LogRecorderManager getLog() {
-        checkPermission(CONFIGURE);
+        checkPermission(ADMINISTER);
         return log;
     }
 

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -5,9 +5,9 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.XmlFile;
 import hudson.model.PersistentDescriptor;
+import hudson.security.Permission;
 import hudson.util.FormValidation;
 import hudson.util.XStream2;
-import jenkins.security.ApiTokenProperty;
 import jenkins.util.SystemProperties;
 import jenkins.util.UrlHelper;
 import org.jenkinsci.Symbol;
@@ -140,6 +140,10 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration implements
     }
 
     public void setUrl(@CheckForNull String jenkinsUrl) {
+        if(!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+            return;
+        }
+
         String url = Util.nullify(jenkinsUrl);
         if(url!=null && !url.endsWith("/"))
             url += '/';

--- a/core/src/main/java/jenkins/security/ResourceDomainConfiguration.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainConfiguration.java
@@ -54,6 +54,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 
+import net.sf.json.JSONObject;
+
 import static jenkins.security.ResourceDomainFilter.ERROR_RESPONSE;
 
 /**
@@ -187,6 +189,14 @@ public final class ResourceDomainConfiguration extends GlobalConfiguration {
     @CheckForNull
     public String getUrl() {
         return url;
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        if(Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+            return super.configure(req, json);
+        }
+        return true;
     }
 
     public void setUrl(@CheckForNull String url) {

--- a/core/src/main/resources/hudson/logging/LogRecorder/index.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorder/index.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<l:layout title="Log" permission="${app.CONFIGURE}">
+<l:layout title="Log" permission="${app.ADMINISTER}">
   <st:include page="sidepanel.jelly" />
   <l:main-panel>
     <h1><l:icon class="icon-clipboard icon-xlg"/>${it.displayName}</h1>

--- a/core/src/main/resources/jenkins/model/JenkinsLocationConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/JenkinsLocationConfiguration/config.groovy
@@ -1,12 +1,15 @@
 package jenkins.model.JenkinsLocationConfiguration
 
 import hudson.Functions
+import jenkins.model.Jenkins
 
 def f=namespace(lib.FormTagLib)
 
 f.section(title:_("Jenkins Location")) {
-    f.entry(title:_("Jenkins URL"), field:"url") {
-        f.textbox(default: Functions.inferHudsonURL(request))
+    if (Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        f.entry(title: _("Jenkins URL"), field: "url") {
+            f.textbox(default: Functions.inferHudsonURL(request))
+        }
     }
     f.entry(title:_("System Admin e-mail address"), field:"adminAddress") {
         f.textbox()

--- a/core/src/main/resources/jenkins/security/ResourceDomainConfiguration/config.jelly
+++ b/core/src/main/resources/jenkins/security/ResourceDomainConfiguration/config.jelly
@@ -24,9 +24,11 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:section title="${%Serve resource files from another domain}">
-        <f:entry title="${%Resource root URL}" field="url">
-            <f:textbox checkMethod="post"/>
-        </f:entry>
-    </f:section>
+    <j:if test="{h.hasPermission(app.ADMINISTER)}">
+        <f:section title="${%Serve resource files from another domain}">
+            <f:entry title="${%Resource root URL}" field="url">
+                <f:textbox checkMethod="post"/>
+            </f:entry>
+        </f:section>
+    </j:if>
 </j:jelly>

--- a/test/src/test/java/hudson/model/ComputerTest.java
+++ b/test/src/test/java/hudson/model/ComputerTest.java
@@ -140,21 +140,15 @@ public class ComputerTest {
 
     @Issue("JENKINS-60266")
     @Test
-    public void dumpExportTableAllowedWithConfigurePermission() throws Exception {
+    public void dumpExportTableForbiddenWithoutAdminPermission() throws Exception {
+        final String READER = "reader";
         final String CONFIGURATOR = "configurator";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                                                   .grant(Jenkins.CONFIGURE, Jenkins.READ).everywhere().to(CONFIGURATOR));
-        Page form = j.createWebClient().login(CONFIGURATOR).goTo("computer/(master)/dumpExportTable", "text/plain");
-        assertEquals(form.getWebResponse().getStatusCode(), 200);
-    }
-
-    @Issue("JENKINS-60266")
-    @Test
-    public void dumpExportTableForbiddenWithoutAdminOrConfigurePermission() throws Exception {
-        final String READER = "reader";
-        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
-        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to(READER));
+                                                   .grant(Jenkins.READ).everywhere().to(READER)
+                                                   .grant(Jenkins.CONFIGURE).everywhere().to(CONFIGURATOR)
+        );
         j.createWebClient().login(READER).assertFails("computer/(master)/dumpExportTable", 403);
+        j.createWebClient().login(CONFIGURATOR).assertFails("computer/(master)/dumpExportTable", 403);
     }
 }

--- a/test/src/test/java/hudson/model/HudsonTest.java
+++ b/test/src/test/java/hudson/model/HudsonTest.java
@@ -256,13 +256,9 @@ public class HudsonTest {
     public void someGlobalConfigCanNotBeModifiedWithConfigurePermission() throws Exception {
         //GIVEN the Global Configuration Form, with some changes unsaved
         int currentNumberExecutors = j.getInstance().getNumExecutors();
-        View primary = j.getInstance().getPrimaryView();
         String shell = getShell();
-        j.getInstance().addView(new ListView("otherView"));
-
         HtmlForm form = j.createWebClient().goTo("configure").getFormByName("config");
         form.getInputByName("_.numExecutors").setValueAttribute(""+(currentNumberExecutors+1));
-        form.getSelectByName("primaryView").setSelectedAttribute("otherView", true);
         form.getInputByName("_.shell").setValueAttribute("/fakeShell");
 
         // WHEN a user with CONFIGURE permission only try to save those changes
@@ -272,7 +268,6 @@ public class HudsonTest {
         j.submit(form);
         // THEN the changes on fields forbidden to a CONFIGURE_JENKINS permission are not saved
         assertEquals("shouldn't be allowed to change the number of executors", currentNumberExecutors, j.getInstance().getNumExecutors());
-        assertEquals("shouldn't be allowed to change the primary view", primary, j.getInstance().getPrimaryView());
         assertEquals("shouldn't be allowed to change the shell executable", shell, getShell());
     }
 


### PR DESCRIPTION
Changes: 

- Fix failing tests in jenkins CI.
- Changes the required permission to modify the Default View from `ADMINISTER` to `CONFIGURE`, in accordance with the [latest JEP version](https://github.com/mikecirioli/jep/tree/b6648cb4fa5ad462a8b049af8f6da1e20bcdefe0/jep/0000#jenkins-ux-changes)
- Address some feedback given in the PR:
  https://github.com/jenkinsci/jenkins/pull/4374#discussion_r350828793
  https://github.com/jenkinsci/jenkins/pull/4374#discussion_r350825784

- Allow modifying Default View with CONFIGURE permission.
  This was discussed in the PR, and we did change the JEP to document that CONFIGURE permission will be allowed to do this. But we forgot about changing it in the code :)
   The input is only shown f the user has permission to see some view (this is the existent behavior)

- Don't allow to edit Resource Root URL or Jenkins URL
  We made this decision and documented it in the JEP but some code changes were missing.
 
- Only allow ADMINISTER to access the logs.
  This decision is explained in this [JEP PR](https://github.com/mikecirioli/jep/pull/8)
