### PR TITLE
Rename Jenkins.CONFIGURE permission to Jenkins.MANAGE

### DIFF
--- a/core/src/main/java/hudson/AboutJenkins.java
+++ b/core/src/main/java/hudson/AboutJenkins.java
@@ -44,7 +44,7 @@ public class AboutJenkins extends ManagementLink {
 
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 
 }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2971,7 +2971,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     private static void checkPermissionForValidate() {
         AccessControlled subject = Stapler.getCurrentRequest().findAncestorObject(AbstractProject.class);
         if (subject == null)
-            Jenkins.get().checkPermission(Jenkins.CONFIGURE);
+            Jenkins.get().checkPermission(Jenkins.MANAGE);
         else
             subject.checkPermission(Item.CONFIGURE);
     }

--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -428,7 +428,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
                 @QueryParameter("userName") String userName, @QueryParameter("secretPassword") Secret password,
                 @QueryParameter("noProxyHost") String noProxyHost) {
 
-            Jenkins.get().checkPermission(Jenkins.CONFIGURE);
+            Jenkins.get().checkPermission(Jenkins.MANAGE);
 
             if (Util.fixEmptyAndTrim(testUrl) == null) {
                 return FormValidation.error(Messages.ProxyConfiguration_TestUrlRequired());

--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -464,12 +464,12 @@ public class OldDataMonitor extends AdministrativeMonitor {
 
         @Override
         public Permission getRequiredPermission() {
-            return Jenkins.CONFIGURE;
+            return Jenkins.MANAGE;
         }
     }
 
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -204,7 +204,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
 
     @RequirePOST
     public void do_launchAll(StaplerRequest req, StaplerResponse rsp) throws IOException {
-        Jenkins.get().checkPermission(Jenkins.CONFIGURE);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
 
         for(Computer c : get_all()) {
             if(c.isLaunchSupported())
@@ -220,7 +220,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
      */
     @RequirePOST
     public void doUpdateNow( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
-        Jenkins.get().checkPermission(Jenkins.CONFIGURE);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
         
         for (NodeMonitor nodeMonitor : NodeMonitor.getAll()) {
             Thread t = nodeMonitor.triggerUpdate();
@@ -347,7 +347,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     public synchronized HttpResponse doConfigSubmit( StaplerRequest req) throws IOException, ServletException, FormException {
         BulkChange bc = new BulkChange(MONITORS_OWNER);
         try {
-            Jenkins.get().checkPermission(Jenkins.CONFIGURE);
+            Jenkins.get().checkPermission(Jenkins.MANAGE);
             monitors.rebuild(req,req.getSubmittedForm(),getNodeMonitorDescriptors());
 
             // add in the rest of instances are ignored instances

--- a/core/src/main/java/hudson/model/ManageJenkinsAction.java
+++ b/core/src/main/java/hudson/model/ManageJenkinsAction.java
@@ -35,7 +35,7 @@ import org.jenkinsci.Symbol;
 @Extension(ordinal=100) @Symbol("manageJenkins")
 public class ManageJenkinsAction implements RootAction {
     public String getIconFileName() {
-        if (Jenkins.get().hasPermission(Jenkins.CONFIGURE))
+        if (Jenkins.get().hasPermission(Jenkins.MANAGE))
             return "gear2.png";
         else
             return null;

--- a/core/src/main/java/hudson/model/labels/LabelAtom.java
+++ b/core/src/main/java/hudson/model/labels/LabelAtom.java
@@ -204,7 +204,7 @@ public class LabelAtom extends Label implements Saveable {
     public void doConfigSubmit( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException, FormException {
         final Jenkins app = Jenkins.get();
 
-        app.checkPermission(Jenkins.CONFIGURE);
+        app.checkPermission(Jenkins.MANAGE);
 
         properties.rebuild(req, req.getSubmittedForm(), getApplicablePropertyDescriptors());
 
@@ -222,7 +222,7 @@ public class LabelAtom extends Label implements Saveable {
     @RequirePOST
     @Restricted(DoNotUse.class)
     public synchronized void doSubmitDescription( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
-        Jenkins.get().checkPermission(Jenkins.CONFIGURE);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
 
         setDescription(req.getParameter("description"));
         rsp.sendRedirect(".");  // go to the top page

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
@@ -57,7 +57,7 @@ public class DiskSpaceMonitor extends AbstractDiskSpaceMonitor {
     @Override
     public String getColumnCaption() {
         // Hide this column from non-admins
-        return Jenkins.get().hasPermission(Jenkins.CONFIGURE) ? super.getColumnCaption() : null;
+        return Jenkins.get().hasPermission(Jenkins.MANAGE) ? super.getColumnCaption() : null;
     }
 
     public static final DiskSpaceMonitorDescriptor DESCRIPTOR = new DiskSpaceMonitorDescriptor() {

--- a/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
@@ -78,7 +78,7 @@ public class SwapSpaceMonitor extends NodeMonitor {
     @Override
     public String getColumnCaption() {
         // Hide this column from non-admins
-        return Jenkins.get().hasPermission(Jenkins.CONFIGURE) ? super.getColumnCaption() : null;
+        return Jenkins.get().hasPermission(Jenkins.MANAGE) ? super.getColumnCaption() : null;
     }
 
     /**

--- a/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
@@ -59,7 +59,7 @@ public class TemporarySpaceMonitor extends AbstractDiskSpaceMonitor {
     @Override
     public String getColumnCaption() {
         // Hide this column from non-admins
-        return Jenkins.get().hasPermission(Jenkins.CONFIGURE) ? super.getColumnCaption() : null;
+        return Jenkins.get().hasPermission(Jenkins.MANAGE) ? super.getColumnCaption() : null;
     }
 
     /**

--- a/core/src/main/java/hudson/util/FormFieldValidator.java
+++ b/core/src/main/java/hudson/util/FormFieldValidator.java
@@ -61,7 +61,7 @@ import static hudson.Util.fixEmpty;
  */
 @Deprecated
 public abstract class FormFieldValidator {
-    public static final Permission CHECK = Jenkins.CONFIGURE;
+    public static final Permission CHECK = Jenkins.MANAGE;
 
     protected final StaplerRequest request;
     protected final StaplerResponse response;
@@ -133,7 +133,7 @@ public abstract class FormFieldValidator {
             } catch (AccessDeniedException e) {
                 // if the user has hudson-wide admin permission, all checks are allowed
                 // this is to protect Hudson administrator from broken ACL/SecurityRealm implementation/configuration.
-                if(!Jenkins.get().hasPermission(Jenkins.CONFIGURE))
+                if(!Jenkins.get().hasPermission(Jenkins.MANAGE))
                     throw e;
             }
 

--- a/core/src/main/java/hudson/views/GlobalDefaultViewConfiguration.java
+++ b/core/src/main/java/hudson/views/GlobalDefaultViewConfiguration.java
@@ -62,7 +62,7 @@ public class GlobalDefaultViewConfiguration extends GlobalConfiguration {
 
     @Override
     public Permission getPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }
 

--- a/core/src/main/java/hudson/views/MyViewsTabBar.java
+++ b/core/src/main/java/hudson/views/MyViewsTabBar.java
@@ -119,7 +119,7 @@ public abstract class MyViewsTabBar extends AbstractDescribableImpl<MyViewsTabBa
 
         @Override
         public Permission getPermission() {
-            return Jenkins.CONFIGURE;
+            return Jenkins.MANAGE;
         }
     }
 }

--- a/core/src/main/java/hudson/views/ViewsTabBar.java
+++ b/core/src/main/java/hudson/views/ViewsTabBar.java
@@ -120,7 +120,7 @@ public abstract class ViewsTabBar extends AbstractDescribableImpl<ViewsTabBar> i
 
         @Override
         public Permission getPermission() {
-            return Jenkins.CONFIGURE;
+            return Jenkins.MANAGE;
         }
     }
 }

--- a/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
@@ -31,7 +31,7 @@ public class URICheckEncodingMonitor extends AdministrativeMonitor {
     }
 
     public FormValidation doCheckURIEncoding(StaplerRequest request) throws IOException {
-        Jenkins.get().checkPermission(Jenkins.CONFIGURE);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
         // expected is non-ASCII String
         final String expected = "\u57f7\u4e8b";
         final String value = fixEmpty(request.getParameter("value"));

--- a/core/src/main/java/jenkins/management/CliLink.java
+++ b/core/src/main/java/jenkins/management/CliLink.java
@@ -59,6 +59,6 @@ public class CliLink extends ManagementLink {
 
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }

--- a/core/src/main/java/jenkins/management/ConfigureLink.java
+++ b/core/src/main/java/jenkins/management/ConfigureLink.java
@@ -59,6 +59,6 @@ public class ConfigureLink extends ManagementLink {
 
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }

--- a/core/src/main/java/jenkins/management/ReloadLink.java
+++ b/core/src/main/java/jenkins/management/ReloadLink.java
@@ -68,6 +68,6 @@ public class ReloadLink extends ManagementLink {
 
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }

--- a/core/src/main/java/jenkins/management/ShutdownLink.java
+++ b/core/src/main/java/jenkins/management/ShutdownLink.java
@@ -62,6 +62,6 @@ public class ShutdownLink extends ManagementLink {
 
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }

--- a/core/src/main/java/jenkins/management/StatisticsLink.java
+++ b/core/src/main/java/jenkins/management/StatisticsLink.java
@@ -59,6 +59,6 @@ public class StatisticsLink extends ManagementLink {
 
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }

--- a/core/src/main/java/jenkins/management/SystemInfoLink.java
+++ b/core/src/main/java/jenkins/management/SystemInfoLink.java
@@ -59,6 +59,6 @@ public class SystemInfoLink extends ManagementLink {
 
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }

--- a/core/src/main/java/jenkins/model/ArtifactManagerConfiguration.java
+++ b/core/src/main/java/jenkins/model/ArtifactManagerConfiguration.java
@@ -68,6 +68,6 @@ public class ArtifactManagerConfiguration extends GlobalConfiguration implements
 
     @Override
     public Permission getPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalProjectNamingStrategyConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalProjectNamingStrategyConfiguration.java
@@ -63,6 +63,6 @@ public class GlobalProjectNamingStrategyConfiguration extends GlobalConfiguratio
 
     @Override
     public Permission getPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalQuietPeriodConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalQuietPeriodConfiguration.java
@@ -61,6 +61,6 @@ public class GlobalQuietPeriodConfiguration extends GlobalConfiguration {
 
     @Override
     public Permission getPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalSCMRetryCountConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalSCMRetryCountConfiguration.java
@@ -58,6 +58,6 @@ public class GlobalSCMRetryCountConfiguration extends GlobalConfiguration {
 
     @Override
     public Permission getPermission() {
-        return Jenkins.CONFIGURE;
+        return Jenkins.MANAGE;
     }
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2278,7 +2278,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @Override
     public SearchIndexBuilder makeSearchIndex() {
         SearchIndexBuilder builder = super.makeSearchIndex();
-        if (hasPermission(CONFIGURE)) {
+        if (hasPermission(MANAGE)) {
                 builder.add("configure", "config", "configure")
                     .add("manage")
                     .add("log");
@@ -3803,7 +3803,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public synchronized void doConfigSubmit( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException, FormException {
         BulkChange bc = new BulkChange(this);
         try {
-            checkPermission(CONFIGURE);
+            checkPermission(MANAGE);
 
             JSONObject json = req.getSubmittedForm();
 
@@ -3899,7 +3899,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @RequirePOST
     public HttpRedirect doQuietDown(@QueryParameter boolean block, @QueryParameter int timeout) throws InterruptedException, IOException {
         synchronized (this) {
-            checkPermission(CONFIGURE);
+            checkPermission(MANAGE);
             isQuietingDown = true;
         }
         if (block) {
@@ -3919,7 +3919,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @RequirePOST // TODO the cancel link needs to be updated accordingly
     public synchronized HttpRedirect doCancelQuietDown() {
-        checkPermission(CONFIGURE);
+        checkPermission(MANAGE);
         isQuietingDown = false;
         getQueue().scheduleMaintenance();
         return new HttpRedirect(".");
@@ -4126,7 +4126,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @RequirePOST
     public synchronized HttpResponse doReload() throws IOException {
-        checkPermission(CONFIGURE);
+        checkPermission(MANAGE);
         LOGGER.log(Level.WARNING, "Reloading Jenkins as requested by {0}", getAuthentication().getName());
 
         // engage "loading ..." UI and then run the actual task in a separate thread
@@ -4265,7 +4265,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @CLIMethod(name="restart")
     public void doRestart(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, RestartNotSupportedException {
-        checkPermission(CONFIGURE);
+        checkPermission(MANAGE);
         if (req != null && req.getMethod().equals("GET")) {
             req.getView(this,"_restart.jelly").forward(req,rsp);
             return;
@@ -4289,7 +4289,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @CLIMethod(name="safe-restart")
     public HttpResponse doSafeRestart(StaplerRequest req) throws IOException, ServletException, RestartNotSupportedException {
-        checkPermission(CONFIGURE);
+        checkPermission(MANAGE);
         if (req != null && req.getMethod().equals("GET"))
             return HttpResponses.forwardToView(this,"_safeRestart.jelly");
 
@@ -4404,7 +4404,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @CLIMethod(name="shutdown")
     @RequirePOST
     public void doExit( StaplerRequest req, StaplerResponse rsp ) throws IOException {
-        checkPermission(CONFIGURE);
+        checkPermission(MANAGE);
         if (rsp!=null) {
             rsp.setStatus(HttpServletResponse.SC_OK);
             rsp.setContentType("text/plain");
@@ -4437,7 +4437,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @CLIMethod(name="safe-shutdown")
     @RequirePOST
     public HttpResponse doSafeExit(StaplerRequest req) throws IOException {
-        checkPermission(CONFIGURE);
+        checkPermission(MANAGE);
         isQuietingDown = true;
         final String exitUser = getAuthentication().getName();
         final String exitAddr = req!=null ? req.getRemoteAddr() : "unknown";
@@ -5280,7 +5280,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Allows non-privilege escalating configuration permission for a Jenkins instance.  Actions which could result
      * in a privilege  escalation (such as RUN_SCRIPTS) require explicit ADMINISTER permission
      */
-    public static final Permission CONFIGURE = new Permission(PERMISSIONS, "Configure", Messages._Hudson_ConfigureJenkins_Description(),ADMINISTER, PermissionScope.JENKINS);
+    public static final Permission MANAGE = new Permission(PERMISSIONS, "Manage", Messages._Hudson_ConfigureJenkins_Description(),ADMINISTER, PermissionScope.JENKINS);
     public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),Permission.READ,PermissionScope.JENKINS);
     public static final Permission RUN_SCRIPTS = new Permission(PERMISSIONS, "RunScripts", Messages._Hudson_RunScriptsPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
 

--- a/test/src/test/java/hudson/AboutJenkinsTest.java
+++ b/test/src/test/java/hudson/AboutJenkinsTest.java
@@ -55,7 +55,7 @@ public class AboutJenkinsTest {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                 .grant(Jenkins.ADMINISTER).everywhere().to(ADMIN)
-                .grant(Jenkins.CONFIGURE, Jenkins.READ).everywhere().to(CONFIGURATOR)
+                .grant(Jenkins.MANAGE, Jenkins.READ).everywhere().to(CONFIGURATOR)
                 .grant(Jenkins.READ).everywhere().to(USER)
         );
         

--- a/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
@@ -95,7 +95,7 @@ public class CancelQuietDownCommandTest {
         //GIVEN a user with CONFIGURE_JENKINS permission
         //WHEN cancel quiet down is called
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Jenkins.CONFIGURE)
+                .authorizedTo(Jenkins.READ, Jenkins.MANAGE)
                 .invoke();
         //THEN cancel quietDown worked
         assertThat(result, succeededSilently());

--- a/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
@@ -337,7 +337,7 @@ public class DisablePluginCommandTest {
         //GIVEN a user with CONFIGURE_JENKINS permission
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                                                   .grant(Jenkins.CONFIGURE).everywhere().to("configurator")
+                                                   .grant(Jenkins.MANAGE).everywhere().to("configurator")
         );
 
         //WHEN trying to disable a plugin

--- a/test/src/test/java/hudson/cli/InstallPluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/InstallPluginCommandTest.java
@@ -73,7 +73,7 @@ public class InstallPluginCommandTest {
         setupUpdateCenter();
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.ADMINISTER).everywhere().to(
-                "admin").grant(Jenkins.CONFIGURE).everywhere().to("configurator"));
+                "admin").grant(Jenkins.MANAGE).everywhere().to("configurator"));
 
         String plugin = "git";
 

--- a/test/src/test/java/hudson/cli/QuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/QuietDownCommandTest.java
@@ -85,7 +85,7 @@ public class QuietDownCommandTest {
     @Test
     public void quietDownShouldSuccessWithConfigurePermission() throws Exception {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Jenkins.CONFIGURE)
+                .authorizedTo(Jenkins.READ, Jenkins.MANAGE)
                 .invoke();
         assertThat(result, succeededSilently());
         assertJenkinsInQuietMode();

--- a/test/src/test/java/hudson/cli/ReloadConfigurationCommandTest.java
+++ b/test/src/test/java/hudson/cli/ReloadConfigurationCommandTest.java
@@ -82,7 +82,7 @@ public class ReloadConfigurationCommandTest {
     @Test
     public void reloadConfigurationShouldWorkWithConfigurePermission() throws Exception {
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                                                   .grant(Jenkins.CONFIGURE, Jenkins.READ).everywhere().toAuthenticated());
+                                                   .grant(Jenkins.MANAGE, Jenkins.READ).everywhere().toAuthenticated());
         //Any reload configuration should work with CONFIGURE_JENKINS as well
         this.reloadMasterConfig();
     }

--- a/test/src/test/java/hudson/model/ComputerSetTest.java
+++ b/test/src/test/java/hudson/model/ComputerSetTest.java
@@ -93,7 +93,7 @@ public class ComputerSetTest {
 
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                                                   .grant(Jenkins.CONFIGURE, Jenkins.READ).everywhere().to(CONFIGURATOR));
+                                                   .grant(Jenkins.MANAGE, Jenkins.READ).everywhere().to(CONFIGURATOR));
         //WHEN the user go to Monitors
         WebClient client = j.createWebClient();
         HtmlPage page = client.withBasicCredentials(CONFIGURATOR).goTo("computer");
@@ -123,7 +123,7 @@ public class ComputerSetTest {
     }
 
     /**
-     * Tests that user with {@link Jenkins#CONFIGURE} can submit configuration form
+     * Tests that user with {@link Jenkins#MANAGE} can submit configuration form
      */
     @Issue("JENKINS-60266")
     @Test
@@ -132,7 +132,7 @@ public class ComputerSetTest {
 
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                                                   .grant(Jenkins.READ, Jenkins.CONFIGURE).everywhere().to(CONFIGURATOR));
+                                                   .grant(Jenkins.READ, Jenkins.MANAGE).everywhere().to(CONFIGURATOR));
 
         WebClient client = j.createWebClient();
         HtmlForm form = client.login(CONFIGURATOR).goTo("computer/configure").getFormByName("config");

--- a/test/src/test/java/hudson/model/ComputerTest.java
+++ b/test/src/test/java/hudson/model/ComputerTest.java
@@ -146,7 +146,7 @@ public class ComputerTest {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                                                    .grant(Jenkins.READ).everywhere().to(READER)
-                                                   .grant(Jenkins.CONFIGURE).everywhere().to(CONFIGURATOR)
+                                                   .grant(Jenkins.MANAGE).everywhere().to(CONFIGURATOR)
                                                    .grant(Jenkins.READ).everywhere().to(CONFIGURATOR)
         );
         j.createWebClient().login(READER).assertFails("computer/(master)/dumpExportTable", 403);

--- a/test/src/test/java/hudson/model/HudsonTest.java
+++ b/test/src/test/java/hudson/model/HudsonTest.java
@@ -222,7 +222,7 @@ public class HudsonTest {
     public void globalConfigAllowedWithConfigurePermission() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                                                   .grant(Jenkins.CONFIGURE, Jenkins.READ).everywhere().toEveryone());
+                                                   .grant(Jenkins.MANAGE, Jenkins.READ).everywhere().toEveryone());
 
         HtmlForm form = j.createWebClient().goTo("configure").getFormByName("config");
         HtmlPage updated = j.submit(form);
@@ -236,7 +236,7 @@ public class HudsonTest {
         //GIVEN a user with CONFIGURE permission
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                                                   .grant(Jenkins.CONFIGURE, Jenkins.READ).everywhere().toEveryone());
+                                                   .grant(Jenkins.MANAGE, Jenkins.READ).everywhere().toEveryone());
 
         //WHEN the user goes to /configure page
         HtmlForm form = j.createWebClient().goTo("configure").getFormByName("config");
@@ -264,7 +264,7 @@ public class HudsonTest {
         // WHEN a user with CONFIGURE permission only try to save those changes
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                                                   .grant(Jenkins.CONFIGURE, Jenkins.READ).everywhere().toEveryone());
+                                                   .grant(Jenkins.MANAGE, Jenkins.READ).everywhere().toEveryone());
         j.submit(form);
         // THEN the changes on fields forbidden to a CONFIGURE_JENKINS permission are not saved
         assertEquals("shouldn't be allowed to change the number of executors", currentNumberExecutors, j.getInstance().getNumExecutors());

--- a/test/src/test/java/hudson/model/labels/LabelAtomPropertyTest.java
+++ b/test/src/test/java/hudson/model/labels/LabelAtomPropertyTest.java
@@ -85,7 +85,7 @@ public class LabelAtomPropertyTest {
         final String CONFIGURATOR = "configurator";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                                                   .grant(Jenkins.READ, Jenkins.CONFIGURE).everywhere().to(CONFIGURATOR));
+                                                   .grant(Jenkins.READ, Jenkins.MANAGE).everywhere().to(CONFIGURATOR));
 
         LabelAtom label = j.jenkins.getLabelAtom("foo");
 

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -711,7 +711,7 @@ public class JenkinsTest {
     @Test
     public void doExitSuccessWithConfigurePermission() {
         CLICommandInvoker.Result result = new CLICommandInvoker(j, "shutdown")
-                .authorizedTo(Jenkins.READ, Jenkins.CONFIGURE)
+                .authorizedTo(Jenkins.READ, Jenkins.MANAGE)
                 .invoke();
         assertThat(result, succeededSilently());
     }
@@ -720,7 +720,7 @@ public class JenkinsTest {
     @Test
     public void doSafeExitSuccessWithConfigurePermission() {
         CLICommandInvoker.Result result = new CLICommandInvoker(j, "safe-shutdown")
-                .authorizedTo(Jenkins.READ, Jenkins.CONFIGURE)
+                .authorizedTo(Jenkins.READ, Jenkins.MANAGE)
                 .invoke();
         assertThat(result, succeededSilently());
     }


### PR DESCRIPTION
Based on feedback, I propose renaming the `Jenkins.CONFIGURE` to `Jenkins.MANAGE`.  This should make the permission more intuitive for users as the permission will be better aligned with `Overall/ADMINISTER`, and `Overall/READ`:

![Screen Shot 2020-01-22 at 1 34 21 PM](https://user-images.githubusercontent.com/8135503/72923834-cf54ab80-3d1d-11ea-8ad3-96e0b0f2507d.png)

For comparison, here is an artist's rendering of what this might look like if additional proposed permissions become a reality:
![manage_permission_matrix_auth_2](https://user-images.githubusercontent.com/8135503/72945484-ee693280-3d49-11ea-862f-88e6c27a6467.png)

If additional limited/partial/`ADMINISTER` "light" permissions are added, it may make more sense to group them separately in their own group.  In that case, possibly something like the following would make the most sense (arrow indicates where this should actually show up in the ux):
![manage_permission_matrix_auth_3](https://user-images.githubusercontent.com/8135503/72948668-da2a3300-3d53-11ea-8361-3de9d7ec9646.png)


Feedback appreciated on these 3 different approaches!


