### PR TITLE
Allow user with Jenkins.MANAGE permission to view plugin dependenc…

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -438,7 +438,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     }
 
     public Api getApi() {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) return null;
         return new Api(this);
     }
 

--- a/core/src/main/resources/hudson/AboutJenkins/index.jelly
+++ b/core/src/main/resources/hudson/AboutJenkins/index.jelly
@@ -52,12 +52,11 @@ THE SOFTWARE.
             <li><a href="http://fontawesome.io">Font Awesome</a>, created by <a href="https://twitter.com/davegandy">Dave Gandy</a>. <a href="http://scripts.sil.org/OFL">SIL OFL 1.1 License</a> and <a href="http://opensource.org/licenses/mit-license.html">MIT License</a></li>
             <li><a href="https://www.google.com/fonts/specimen/Roboto">Google Fonts: Roboto</a>, created by <a href="https://plus.google.com/110879635926653430880/about">Christian Robertson</a>. <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License, version 2.0</a></li>
           </ul>
-          <j:if test="${h.hasPermission(app.ADMINISTER)}">
             <h2>${%plugin.dependencies}</h2>
             <ul>
               <j:forEach var="p" items="${app.pluginManager.plugins}"> <!-- TODO sort -->
               <li>
-                <a href="${rootURL}/pluginManager/plugin/${p.shortName}/thirdPartyLicenses">
+                <a href="${rootURL}/plugin/${p.shortName}/wrapper/thirdPartyLicenses">
                   <j:choose>
                     <j:when test="${p.active}">
                       ${p.displayName}
@@ -70,7 +69,6 @@ THE SOFTWARE.
               </li>
               </j:forEach>
             </ul>
-          </j:if>
         </div>
       </div>
     </div>

--- a/core/src/main/resources/hudson/AboutJenkins/index.jelly
+++ b/core/src/main/resources/hudson/AboutJenkins/index.jelly
@@ -52,23 +52,25 @@ THE SOFTWARE.
             <li><a href="http://fontawesome.io">Font Awesome</a>, created by <a href="https://twitter.com/davegandy">Dave Gandy</a>. <a href="http://scripts.sil.org/OFL">SIL OFL 1.1 License</a> and <a href="http://opensource.org/licenses/mit-license.html">MIT License</a></li>
             <li><a href="https://www.google.com/fonts/specimen/Roboto">Google Fonts: Roboto</a>, created by <a href="https://plus.google.com/110879635926653430880/about">Christian Robertson</a>. <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License, version 2.0</a></li>
           </ul>
-          <h2>${%plugin.dependencies}</h2>
-          <ul>
-            <j:forEach var="p" items="${app.pluginManager.plugins}"> <!-- TODO sort -->
-            <li>
-              <a href="${rootURL}/pluginManager/plugin/${p.shortName}/thirdPartyLicenses">
-                <j:choose>
-                  <j:when test="${p.active}">
-                    ${p.displayName}
-                  </j:when>
-                  <j:otherwise>
-                    <strike>${p.displayName}</strike>
-                  </j:otherwise>
-                </j:choose>
-              </a>
-            </li>
-            </j:forEach>
-          </ul>
+          <j:if test="${h.hasPermission(app.ADMINISTER)}">
+            <h2>${%plugin.dependencies}</h2>
+            <ul>
+              <j:forEach var="p" items="${app.pluginManager.plugins}"> <!-- TODO sort -->
+              <li>
+                <a href="${rootURL}/pluginManager/plugin/${p.shortName}/thirdPartyLicenses">
+                  <j:choose>
+                    <j:when test="${p.active}">
+                      ${p.displayName}
+                    </j:when>
+                    <j:otherwise>
+                      <strike>${p.displayName}</strike>
+                    </j:otherwise>
+                  </j:choose>
+                </a>
+              </li>
+              </j:forEach>
+            </ul>
+          </j:if>
         </div>
       </div>
     </div>

--- a/core/src/main/resources/hudson/PluginWrapper/thirdPartyLicenses.jelly
+++ b/core/src/main/resources/hudson/PluginWrapper/thirdPartyLicenses.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <!-- 3rd party license acknowledgements and  -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-  <l:layout title="${%about(it.longName)}" permission="${app.ADMINISTER}">
+  <l:layout title="${%about(it.longName)}" permission="${app.MANAGE}">
     <l:main-panel>
       <h1>${%about(it.longName+' '+it.version)}</h1>
 


### PR DESCRIPTION
Changes how plugin dependencies are accessed from the "About Jenkins" page so that a user with `Jenkins.MANAGE` permission is able to view them