### PR TITLE
Add third ajax call (build history for job home page)

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -120,6 +120,6 @@ THE SOFTWARE.
   </l:pane>
   </div>
   <script defer="true">
-    updateBuildHistory("${it.baseUrl}/buildHistory/ajax", ${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber});
+    updateBuildHistory("${it.baseUrl}/buildHistory/ajax", ${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber}, ${h.ajaxRefreshInterval});
   </script>
 </j:jelly>

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1765,7 +1765,17 @@ function fireBuildHistoryChanged() {
     Event.fire(window, 'jenkins:buildHistoryChanged');
 }
 
-function updateBuildHistory(ajaxUrl,nBuild) {
+/**
+ * @param ajaxUrl The URL to call to refresh the HTML part
+ * @param nBuild The expected next build id, to retrieve only information not yet present
+ * @param refreshIntervalInSeconds (optional) 5 by default and as minimum - define the interval in seconds between 2 ajax calls.
+ */
+function updateBuildHistory(ajaxUrl, nBuild, refreshIntervalInSeconds) {
+    var refreshInterval = 5000; //default is 5s
+    if(refreshIntervalInSeconds != undefined && refreshIntervalInSeconds >= 5) {
+        refreshInterval = 1000 * refreshIntervalInSeconds;
+    }
+    
     if(isRunAsTest) return;
     var bh = $('buildHistory');
     
@@ -2076,7 +2086,6 @@ function updateBuildHistory(ajaxUrl,nBuild) {
         }
     }
 
-    var updateBuildsRefreshInterval = 5000;
     function updateBuilds() {
         if(isPageVisible()){
             if (bh.headers == null) {
@@ -2136,7 +2145,7 @@ function updateBuildHistory(ajaxUrl,nBuild) {
     var buildRefreshTimeout;
     function createRefreshTimeout() {
         cancelRefreshTimeout();
-        buildRefreshTimeout = window.setTimeout(updateBuilds, updateBuildsRefreshInterval);
+        buildRefreshTimeout = window.setTimeout(updateBuilds, refreshInterval);
     }
     function cancelRefreshTimeout() {
         if (buildRefreshTimeout) {


### PR DESCRIPTION
<details>

<summary>Screenshot of the network tab</summary>

After `System.setProperty("jenkins.ui.ajaxRefreshInterval", "10")`

![Screenshot-2020-10-18_12-25-48](https://user-images.githubusercontent.com/2662497/96364928-7e9fa100-113d-11eb-98c5-718b080400c9.png)


</details>


For the job home page, especially the left widget "Build History".